### PR TITLE
Add additional font directory

### DIFF
--- a/src/constants/_defaultSettings.ts
+++ b/src/constants/_defaultSettings.ts
@@ -7,7 +7,7 @@ export const DEFAULT_SETTINGS: ISettings = {
     windowFrame: false,
     disabledFonts: false,
     exportDir: `${process.env.HOME}/Pictures/Figma`,
-    fontDirs: ["/usr/share/fonts", `${process.env.HOME}/.local/share/fonts`],
+    fontDirs: ["/usr/share/fonts", "/usr/local/share/fonts",`${process.env.HOME}/.local/share/fonts`],
     lastOpenedTabs: [],
   },
   ui: {


### PR DESCRIPTION
On KDE Plasma, fonts are installed into the `/usr/local/` directory.
These fonts wont be detected by default.