### PR TITLE
Application name shouldn't be same with package name

### DIFF
--- a/config/builder.json
+++ b/config/builder.json
@@ -1,6 +1,6 @@
 {
   "appId": "figma-linux",
-  "productName": "figma-linux",
+  "productName": "Figma",
   "extraMetadata": "main/main.js",
   "icon": "resources/icons",
   "extraFiles": [{


### PR DESCRIPTION
productName field in builder config determines the application name in application menu.
I think it's not looking good when it's the same with package name, so I changed it to 'Figma'.