### PR TITLE
Make AppImage executable before installing

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,12 @@ sudo smart install figma-linux-0.5.7.x86_64.rpm
 ```
 
 ## AppImage
-For normal work of the app via AppImage, you need install it via command:
+For normal work of the app via AppImage, you need to
+make it an executable
+```bash
+chmod +x figma-linux-0.6.1.AppImage
+```
+and install it via command:
 ```bash
 sudo ./figma-linux-0.6.1.AppImage -i
 ```


### PR DESCRIPTION
I tried installing with the `AppImage` but it wouldn't install.
I realized I needed to make the file executable before running the install command.
This pull request adds:
`chmod +x figma-linux-0.6.1.AppImage`
before install command in the README.md to help novices like me install this awesome app without complains.
thank you.