### PR TITLE
Fix to make window snapping work again

### DIFF
--- a/src/main/window/WindowManager.ts
+++ b/src/main/window/WindowManager.ts
@@ -63,6 +63,7 @@ class WindowManager {
       width: 1200,
       height: 900,
       frame: false,
+      resizable: true,
       webPreferences: {
         sandbox: false,
         zoomFactor: 1,


### PR DESCRIPTION
If resizable is set to false, users can't drag the window to the edge of the screen to resize it using the snapping feature, as seen on GNOME, KDE and other desktop environments.

This simple fix allows users to snap the application's window. It'll now work on most Desktop Environments with the window snapping feature. 

If kept the way it was, the strange behaviour that would keep happening (as it is happening in the latest stable version) is that the window won't resize when dragging to the screen edges, it will just abruptly stop at the edge. This is not only annoying, but also different from EVERY other application's window behaviour when being dragged to the edges (or "snapped").