### PR TITLE
perf: move Chromium flags to app code

### DIFF
--- a/resources/figma-linux-appimage.desktop
+++ b/resources/figma-linux-appimage.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Figma Linux
 Comment=Unofficial desktop application for linux
-Exec=figma-linux --no-sandbox --enable-oop-rasterization --ignore-gpu-blacklist -enable-experimental-canvas-features --enable-accelerated-2d-canvas --force-gpu-rasterization --enable-fast-unload --enable-accelerated-vpx-decode=3 --enable-tcp-fastopen --javascript-harmony --enable-checker-imaging --v8-cache-options=code --v8-cache-strategies-for-cache-storage=aggressive --enable-zero-copy --ui-enable-zero-copy --enable-native-gpu-memory-buffers --enable-webgl-image-chromium --enable-accelerated-video --enable-gpu-rasterization %U
+Exec=figma-linux %U
 Terminal=false
 Type=Application
 Icon=figma-linux

--- a/resources/figma-linux-snap.desktop
+++ b/resources/figma-linux-snap.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Figma Linux
 Comment=Unofficial desktop application for linux
-Exec=figma-linux --no-sandbox --enable-oop-rasterization --ignore-gpu-blacklist -enable-experimental-canvas-features --enable-accelerated-2d-canvas --force-gpu-rasterization --enable-fast-unload --enable-accelerated-vpx-decode=3 --enable-tcp-fastopen --javascript-harmony --enable-checker-imaging --v8-cache-options=code --v8-cache-strategies-for-cache-storage=aggressive --enable-zero-copy --ui-enable-zero-copy --enable-native-gpu-memory-buffers --enable-webgl-image-chromium --enable-accelerated-video --enable-gpu-rasterization %U
+Exec=figma-linux %U
 Terminal=false
 Type=Application
 Icon=${SNAP}/meta/gui/icon.png

--- a/resources/figma-linux.desktop
+++ b/resources/figma-linux.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Figma Linux
 Comment=Unofficial desktop application for linux
-Exec=/opt/figma-linux/figma-linux --no-sandbox --enable-oop-rasterization --ignore-gpu-blacklist -enable-experimental-canvas-features --enable-accelerated-2d-canvas --force-gpu-rasterization --enable-fast-unload --enable-accelerated-vpx-decode=3 --enable-tcp-fastopen --javascript-harmony --enable-checker-imaging --v8-cache-options=code --v8-cache-strategies-for-cache-storage=aggressive --enable-zero-copy --ui-enable-zero-copy --enable-native-gpu-memory-buffers --enable-webgl-image-chromium --enable-accelerated-video --enable-gpu-rasterization %U
+Exec=/opt/figma-linux/figma-linux %U
 Terminal=false
 Type=Application
 Icon=figma-linux

--- a/src/main/App.ts
+++ b/src/main/App.ts
@@ -51,6 +51,15 @@ class App {
       this.session = new Session();
     }
 
+    // Chromium flags for better performance and GPU support
+    // Full flags reference: https://peter.sh/experiments/chromium-command-line-switches/
+    E.app.commandLine.appendSwitch("no-sandbox");
+    E.app.commandLine.appendSwitch("ignore-gpu-blocklist");
+    E.app.commandLine.appendSwitch("enable-gpu-rasterization");
+    E.app.commandLine.appendSwitch("enable-video-decode");
+    E.app.commandLine.appendSwitch("enable-accelerated-2d-canvas");
+    E.app.commandLine.appendSwitch("enable-experimental-canvas-features");
+
     const colorSpace = storage.get().app.enableColorSpaceSrgb;
 
     if (colorSpace) {


### PR DESCRIPTION
Move Chromium flags from .desktop files to in-app code using Electron's [`appendSwitch`](https://www.electronjs.org/docs/api/command-line-switches#supported-command-line-switches) API.
Ensures the flags are always passed correctly to Chromium and cleans up the codebase a bit - by centralizing where those flags are defined.

cf. [this comment](https://github.com/Figma-Linux/figma-linux/pull/118#issuecomment-847916522) in #118

related: #90