### PR TITLE
Change category to graphics

### DIFF
--- a/config/builder.json
+++ b/config/builder.json
@@ -43,8 +43,8 @@
   "linux": {
     "description": "Unofficial desktop application for linux",
     "icon": "resources/icons",
-    "category": "Graphic",
-    "packageCategory": "Graphic",
+    "category": "Graphics",
+    "packageCategory": "Graphics",
     "maintainer": "Chugunov Roman <Zebs-BMK@yandex.ru>",
     "artifactName": "${name}_${version}_${platform}_${arch}.${ext}",
     "fileAssociations": [


### PR DESCRIPTION
I'm getting this warning from Gentoo Quality Assurance:

```
 * QA Notice: This package installs one or more .desktop files that do not
 * pass validation.
 * 
 * 	/usr/share/applications/figma-linux.desktop: error: value "Graphic;" for key "Categories" in group "Desktop Entry" contains an unregistered value "Graphic"; values extending the format should start with "X-"
 *
```
The correct category according to specifications is "Graphics". https://specifications.freedesktop.org/menu-spec/latest/apa.html

And are .desktop files in [resources](https://github.com/Figma-Linux/figma-linux/tree/dev/resources) still necessary?