### PR TITLE
Avoid setting defaultProtocolClient if already set

### DIFF
--- a/src/main/App.ts
+++ b/src/main/App.ts
@@ -76,7 +76,9 @@ class App {
   }
 
   private appEvent = (): void => {
-    E.app.setAsDefaultProtocolClient(Const.PROTOCOL);
+    if (!E.app.isDefaultProtocolClient(Const.PROTOCOL) {
+      E.app.setAsDefaultProtocolClient(Const.PROTOCOL);
+    }
     E.app.allowRendererProcessReuse = false;
 
     E.app.on("ready", this.ready);


### PR DESCRIPTION
Avoid setting defaultProtocolClient if it is already set
Fix issue: https://github.com/Figma-Linux/figma-linux/issues/183