### PR TITLE
Fixes tab sizing for user interactions and adds focus to new tabs.

### DIFF
--- a/src/renderer/components/Tabs/style.scss
+++ b/src/renderer/components/Tabs/style.scss
@@ -17,6 +17,7 @@
   background-color: var(--bg-tab);
   color: var(--fg-tab);
   fill: var(--fg-tab);
+  -webkit-app-region: no-drag;
 
   &:hover {
     background-color: var(--bg-tab-hover);
@@ -37,7 +38,6 @@
     font-size: var(--fontControlSize);
     margin-right: 6px;
     opacity: 0.4;
-    -webkit-app-region: no-drag;
   }
 
   &:hover .tab__text {
@@ -50,7 +50,6 @@
     fill: var(--fg-tab);
     opacity: 0;
     display: inline-flex;
-    -webkit-app-region: no-drag;
 
     &:hover {
       color: var(--fg-tab-hover);


### PR DESCRIPTION
## Tabs Interaction  Area
Fixes the "tabs interaction area" being too small when compared to the actual size of the tabs by making them the entire size of the tab, as exemplified below:
![example](https://user-images.githubusercontent.com/47650391/158079264-d681539e-9722-4696-b881-ad6dd1832c74.png)

## Focus New Tabs
Fixes #262 and #208 by focusing newly created tabs as soon as they're added, except when they're restored, which will keep the main tab focused, as it should, as soon as the app opens.