### PR TITLE
Rename 'getAllLocalFileExtensionIds' due to API change

### DIFF
--- a/src/middleware/webBinding.ts
+++ b/src/middleware/webBinding.ts
@@ -321,7 +321,7 @@ const publicAPI: any = {
 
     return { data: result };
   },
-  async getAllLocalFileExtensionIds() {
+  async getAllLocalManifestFileExtensionIds() {
     const list = await E.ipcRenderer.invoke("getAllLocalFileExtensionIds");
     return { data: list };
   },


### PR DESCRIPTION
The API for initializing local extensions seems to have been renamed, so I updated it and it seems to work.

I just checked the codebase quickly and have no in-dept knowledge. Errors indicated that there's an unhandled message, so I figured it was just renamed.

If someone wants to do a follow up, they might want to remove the plugins item from the native menu, since I believe the `my_plugins` page no longer exists (it's now in the dashboard page UI).

Fixes #294