### PR TITLE
Fix rpm package conflicts with other electron apps

### DIFF
--- a/config/builder.json
+++ b/config/builder.json
@@ -30,6 +30,12 @@
       "figma"
     ]
   }],
+  
+  "rpm": {
+    "fpm": [
+      "--rpm-rpmbuild-define=_build_id_links none"
+    ]
+  },
 
   "pacman": {
     "depends": []


### PR DESCRIPTION
To prevent this from conflicting with other Electron based apps, it's necessary to omit all the symlinks, to achieve this, Electron-builder uses fpm to have an easier way to build linux apps.

The solution is to tell Electron-builder to have some flags on fpm while building the rpm to prevent creating those symlinks.

According to Electron-builder documentation and fpm documentation this option is --rpm-rpmbuild-define "_build_id_links none".

This PR solved #97 & #276 