### PR TITLE
Fix error when missing manifest.ui is treated like a file to be opened

### DIFF
--- a/src/main/ExtensionManager.ts
+++ b/src/main/ExtensionManager.ts
@@ -565,7 +565,7 @@ export default class ExtensionManager {
             for (const file of Object.values(manifestJson.ui)) {
               files.push({ name: file, content: "" });
             }
-          } else {
+          } else if (typeof manifestJson.ui === "string") {
             files.push({ name: manifestJson.ui, content: "" });
           }
 


### PR DESCRIPTION
My plugin manifest has no ui key, because it's not required. However, when trying to "locate this plugin" the figma-linux would try to open figma.ui, causing the following exception:

Error occurred in handler for 'createMultipleNewLocalFileExtensions': TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of t ype string. Received undefined
    at new NodeError (node:internal/errors:405:5)
    at validateString (node:internal/validators:162:11)
    at Object.extname (node:path:1385:5)
    at _hasFigmaSession.validateFileName (/proj/figma-linux/dist/main/main.js:1:69605)
    at _hasFigmaSession.validateExtensionFiles (/proj/figma-linux/dist/main/main.js:1:70078)
    at _hasFigmaSession.addExtension (/proj/figma-linux/dist/main/main.js:1:68834)
    at o (/proj/figma-linux/dist/main/main.js:1:71542)
    at async Promise.all (index 0)
    at async _hasFigmaSession.createMultipleNewLocalFileExtensions (/proj/figma-linux/dist/main/main.js:1:71629)
    at async WebContents.<anonymous> (node:electron/js2c/browser_init:2:88640) {
  code: 'ERR_INVALID_ARG_TYPE'
}