### PR TITLE
fix: set appVersion to ignore version checking. Closes #371 #372 #373

### DIFF
--- a/src/renderer/DesktopAPI/webBinding.ts
+++ b/src/renderer/DesktopAPI/webBinding.ts
@@ -7,10 +7,12 @@ import { isPrototypeUrl, isValidFigjamLink, isValidProjectLink } from "Utils/Com
 
 interface IntiApiOptions {
   version: number;
+  appVersion: string;
   fileBrowser: boolean;
 }
 
-const API_VERSION = 100;
+const API_VERSION = 111;
+const APP_VERSION = '999.0.0';
 let webPort: MessagePort;
 const mainProcessCancelCallbacks: Map<number, () => void> = new Map();
 
@@ -78,6 +80,7 @@ const initWebApi = (props: IntiApiOptions) => {
 
   window.__figmaDesktop = {
     version: props.version,
+    appVersion: props.appVersion,
     fileBrowser: props.fileBrowser,
     postMessage: function (name, args, transferList): void {
       console.log("postMessage, name, args, transferList: ", name, args, transferList);
@@ -477,6 +480,7 @@ const init = (fileBrowser: boolean): void => {
 
   const initWebOptions: IntiApiOptions = {
     version: API_VERSION,
+    appVersion: APP_VERSION,
     fileBrowser: fileBrowser,
   };
 

--- a/src/types/Renderer/index.d.ts
+++ b/src/types/Renderer/index.d.ts
@@ -8,6 +8,7 @@ interface Window
     WindowEventHandlers {
   __figmaDesktop: {
     version: number;
+    appVersion: string;
     fileBrowser: boolean;
 
     postMessage(name: string, args?: any, transferList?: Transferable[]): void;


### PR DESCRIPTION
Found version checking script inside of figma source code.
![image](https://github.com/Figma-Linux/figma-linux/assets/29871037/8ebe88ec-9458-46fb-bd45-2d9173ff2c89)
![image](https://github.com/Figma-Linux/figma-linux/assets/29871037/a3148ca5-ae67-4cd9-b8ab-438ce10f31a3)

That code was used in `c()` function
![image](https://github.com/Figma-Linux/figma-linux/assets/29871037/a7c60817-453e-4bba-a112-8b26c9f12478)
and used to display unsupported figma version dialog
![image](https://github.com/Figma-Linux/figma-linux/assets/29871037/11c60139-9280-4cc5-a9ac-317f90c65851)


I just added appVersion into window.__figmaDesktop to skip userAgent check because userAgent change in session didnt work
![image](https://github.com/Figma-Linux/figma-linux/assets/29871037/abe12b96-5998-4945-9ae7-a12b99b58ad0)

UserAgent don't change after that manipulations
![image](https://github.com/Figma-Linux/figma-linux/assets/29871037/8e47b9f1-ad6a-42f3-a821-b2d712ddb3c1)

Here is the proof:
![image](https://github.com/Figma-Linux/figma-linux/assets/29871037/fb982cdd-0477-48cd-a365-6f873ddf4e75)


